### PR TITLE
Style web feed

### DIFF
--- a/pages/feed.xml
+++ b/pages/feed.xml
@@ -7,6 +7,7 @@ lang: en
 permalink: /feed.xml
 -->
 <?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="/static/feed.xsl" type="text/xsl"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>{{page.frontmatter.title}}</title>
   <subtitle>{{page.frontmatter.description}}</subtitle>

--- a/public/_headers
+++ b/public/_headers
@@ -12,3 +12,10 @@
 
 /notes*
   Cache-Control: max-age=600, must-revalidate
+
+# Feed
+# The feed with an XSL stylesheet shouldn't be served as application/rss+xml. See https://github.com/genmon/aboutfeeds/blob/main/tools/pretty-feed-v3.xsl
+
+/feed.xml
+  Content-Type: application/xml; charset=utf-8
+  x-content-type-options: nosniff

--- a/public/static/feed.xsl
+++ b/public/static/feed.xsl
@@ -13,7 +13,7 @@
                 <link rel="icon" href="/static/favicon-20220314.png" />
             </head>
             <body>
-                <main style="max-width: 768px; padding: var(--space-3xl) var(--space-2xl); margin: auto;">
+                <main style="max-width: 768px; padding: var(--space-xl) var(--space-m); margin: auto;">
                     <h1>RSS feed</h1>
                     <p style="margin-bottom: var(--space-l);">This is an RSS feed. Subscribe by copying the URL into your newsreader. Visit <a href="https://aboutfeeds.com">About Feeds</a> to learn more and get started.</p>
                     <h2 style="margin-bottom: var(--space-s);">Latest posts</h2>

--- a/public/static/feed.xsl
+++ b/public/static/feed.xsl
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:atom="http://www.w3.org/2005/Atom">
+    <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+    <xsl:template match="/">
+        <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+            <head>
+                <meta charset="utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+                <title>RSS feed | <xsl:value-of select="/atom:feed/atom:title"/></title>
+                <meta name="color-scheme" content="light dark" />
+                <link rel="stylesheet" href="/static/styles/global-20230303.css" />
+                <link rel="icon" href="/static/favicon-20220314.png" />
+            </head>
+            <body>
+                <main style="max-width: 768px; padding: var(--space-3xl) var(--space-2xl); margin: auto;">
+                    <h1>RSS feed</h1>
+                    <p style="margin-bottom: var(--space-l);">This is an RSS feed. Subscribe by copying the URL into your newsreader. Visit <a href="https://aboutfeeds.com">About Feeds</a> to learn more and get started.</p>
+                    <h2 style="margin-bottom: var(--space-s);">Latest posts</h2>
+                    <ul style="margin-bottom: var(--space-2xl);">
+                        <xsl:for-each select="/atom:feed/atom:entry">
+                            <li style="margin-bottom: var(--space-xs);">
+                                <a>
+                                    <xsl:attribute name="href">
+                                        <xsl:value-of select="atom:link/@href"/>
+                                    </xsl:attribute>
+                                    <xsl:value-of select="atom:title"/>
+                                </a>
+                                (<xsl:value-of select="substring(atom:published, 0, 11)" />)
+                            </li>
+                        </xsl:for-each>
+                    </ul>
+                    <a>
+                        <xsl:attribute name="href">
+                            <xsl:value-of select="/atom:feed/atom:link[1]/@href"/>
+                        </xsl:attribute>
+                        Back to homepage
+                    </a>
+                </main>
+            </body>
+        </html>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
The feed structure and styles are intentionally kept minimal.

Based on:

- Darek Kay's [RSS styling blog post](https://darekkay.com/blog/rss-styling/)
- the [pretty-feed RSS stylesheet](https://github.com/genmon/aboutfeeds/blob/main/tools/pretty-feed-v3.xsl) (especially the comment about required headers)

Benefits:

- possibility to add an intro about feeds for people who land on `/feed.xml`
- human-readable list of feed items

Drawbacks:

- according to pretty-feed, browsers won't automatically open the feed in the default newsreader. I think this is fine, because people who already have a newsreader should hopefully know how to add a feed by URL
- had to serve the feed with specific headers (done in Cloudflare Pages via the _headers file), otherwise according to pretty-feed Safari won't recognize the document
- had to duplicate some of the template's `head` into the XSL stylesheet (title, CSS import, color scheme meta tag...). This could technically be reused with templating... but I don't think I want to add .xsl to brut as a valid page extension